### PR TITLE
Removes "files" from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,9 +12,6 @@
     "url": "https://github.com/aldeed/node-message-box/issues"
   },
   "homepage": "https://github.com/aldeed/node-message-box",
-  "files": [
-    "dist"
-  ],
   "main": "./dist/MessageBox.js",
   "scripts": {
     "build": "rm -rf dist/** && babel lib --out-dir dist --ignore *.tests.js",


### PR DESCRIPTION
Remove the files property from package.json so we can access the package directly from GitHub.